### PR TITLE
Observe Compose State through ComposeLocalStore

### DIFF
--- a/arch/build.gradle
+++ b/arch/build.gradle
@@ -26,6 +26,17 @@ android {
         jvmTarget = "1.8"
         allWarningsAsErrors = true
     }
+    buildFeatures {
+        compose = true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.1.0-rc02"
+    }
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
 }
 
 dependencies {
@@ -33,6 +44,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-reflect:${versions.kotlin}"
     //implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlin_version"
     implementation "com.jakewharton.timber:timber:${versions.timber}"
+    implementation "androidx.compose.runtime:runtime:${versions.compose}"
 
     implementation "junit:junit:${versions.junit}"
     testImplementation "junit:junit:${versions.junit}"
@@ -41,4 +53,9 @@ dependencies {
     implementation "androidx.arch.core:core-runtime:${versions.archCore}"
     implementation "androidx.lifecycle:lifecycle-livedata-core-ktx:${versions.lifecycle}"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:${versions.lifecycle}"
+
+    debugImplementation("androidx.compose.ui:ui-test-manifest:${versions.compose}")
+
+    testImplementation "androidx.compose.ui:ui-test-junit4:${versions.compose}"
+    testImplementation "org.robolectric:robolectric:4.7.3"
 }

--- a/arch/src/main/java/dk/ufst/arch/ComposeLocalStore.kt
+++ b/arch/src/main/java/dk/ufst/arch/ComposeLocalStore.kt
@@ -1,0 +1,65 @@
+package dk.ufst.arch
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisallowComposableCalls
+import androidx.compose.runtime.State
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+
+interface ComposeLocalStore<Value, Action> {
+    val state: State<Value>
+        @Composable
+        get
+    fun send(action: Action)
+}
+
+@Composable
+inline fun <LocalValue, LocalAction, GlobalValue, reified GlobalAction, GlobalEnvironment> rememberLocalStore(
+    globalStore: GlobalStore<GlobalValue, GlobalAction, GlobalEnvironment>,
+    crossinline getLocalCopy: @DisallowComposableCalls (GlobalValue) -> LocalValue,
+    crossinline getInitialValue: @DisallowComposableCalls (GlobalValue) -> LocalValue,
+): ComposeLocalStore<LocalValue, LocalAction> {
+    val localStore = remember {
+        object : ComposeLocalStore<LocalValue, LocalAction> {
+            override fun send(action: LocalAction) {
+                if (action is GlobalAction) {
+                    globalStore.sendAction(action as GlobalAction)
+                }
+            }
+
+            override val state: State<LocalValue>
+                @Composable
+                get() = observeAsState()
+
+            @Composable
+            private fun observeAsState(): State<LocalValue> {
+                var prevLocalValue: LocalValue? = null
+
+                return produceState(getInitialValue(globalStore.value)) {
+                    val stateChanger: ((GlobalValue) -> Unit) = { globalValue: GlobalValue ->
+
+                        val newLocalValue = getLocalCopy(globalValue)
+                        // Only update value if the local state have changed.
+                        if (prevLocalValue != newLocalValue) {
+                            if (BuildConfig.DEBUG) {
+                                prevLocalValue?.let {
+                                    logStateDiff(it, newLocalValue!!)
+                                }
+                            }
+                            value = newLocalValue
+                        }
+                        prevLocalValue = newLocalValue
+                    }
+
+                    globalStore.subscribe(stateChanger)
+
+                    awaitDispose {
+                        globalStore.desubscribe(stateChanger)
+                    }
+                }
+            }
+        }
+    }
+
+    return localStore
+}

--- a/arch/src/test/java/dk/ufst/arch/ComposeLocalStoreTest.kt
+++ b/arch/src/test/java/dk/ufst/arch/ComposeLocalStoreTest.kt
@@ -1,0 +1,128 @@
+package dk.ufst.arch
+
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.consumeEach
+import kotlinx.coroutines.launch
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ComposeLocalStoreTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+    private lateinit var globalStore: GlobalStore<AppState, Any, Any>
+
+    @Before
+    fun setup() {
+        setupStore()
+    }
+
+    @Test
+    fun `Test correct recomposition and State data are observed`() {
+        val composedResults = mutableListOf<LocalState>()
+        // Signal an action sent from the Compose scope to the reducer.
+        val signalAction = Channel<Unit>(1)
+
+        composeTestRule.setContent {
+            val localStore: ComposeLocalStore<LocalState, Any> = rememberLocalStore(
+                globalStore,
+                { it.localState.copy() },
+                { it.localState.copy() }
+            )
+
+            composedResults.add(localStore.state.value)
+
+            val scope = rememberCoroutineScope()
+
+            // Wait for outside signal for when to sent an Action.
+            scope.launch {
+                signalAction.consumeEach {
+                    localStore.send(Any())
+                }
+            }
+        }
+
+        composeTestRule.runOnIdle {
+            assertEquals(composedResults.single().value, 1)
+            signalAction.trySend(Unit)
+        }
+
+        composeTestRule.runOnIdle {
+            assertEquals(composedResults.size, 2)
+            assertEquals(composedResults.first().value, 1)
+            assertEquals(composedResults.last().value, 2)
+        }
+    }
+
+    @Test
+    fun `Test no recomposition when forgetting to use copied initial and local values`() {
+        val composedResults = mutableListOf<LocalState>()
+        // Signal an action sent from the Compose scope to the reducer.
+        val signalAction = Channel<Unit>(1)
+
+        composeTestRule.setContent {
+            val localStore: ComposeLocalStore<LocalState, Any> = rememberLocalStore(
+                globalStore,
+                { it.localState },
+                { it.localState }
+            )
+
+            composedResults.add(localStore.state.value)
+
+            val scope = rememberCoroutineScope()
+
+            // Wait for outside signal for when to sent an Action.
+            scope.launch {
+                signalAction.consumeEach {
+                    localStore.send(Any())
+                }
+            }
+        }
+
+        composeTestRule.runOnIdle {
+            assertEquals(composedResults.single().value, 1)
+            signalAction.trySend(Unit)
+        }
+
+        composeTestRule.runOnIdle {
+            assertEquals(composedResults.single().value, 2)
+        }
+    }
+
+    private fun setupStore() {
+        globalStore = GlobalStore(
+            env = Any(),
+            executor = TestExecutor(),
+            initialValue = AppState(),
+            copyValue = { appState ->
+                appState.copy()
+            },
+            reducer = compose(
+                combine(
+                    pullback(
+                        localReducer,
+                        AppState::localState::get,
+                        AppState::localState::set,
+                        { Any() }
+                    )
+                )
+            )
+        )
+    }
+
+    companion object {
+        private data class LocalState(var value: Int = 1)
+        private data class AppState(var localState: LocalState = LocalState())
+
+        private val localReducer: ReducerFunc<LocalState, Any, Any> = { localValue, _, _ ->
+            localValue.value = 2
+            emptyArray()
+        }
+    }
+}


### PR DESCRIPTION
The `ComposeLocalStore` interface is the Compose version of the current `LocalStore` interface.
Instead the `ComposeLocalStore` interface exposes `State<T> `which can be used in Compose context.

@biscon do you always prefer we extend `ReduxArchTest` in our tests?
