### PR TITLE
ComposeLocalStore fix that no longer causes multiple state updates & test

### DIFF
--- a/arch/build.gradle
+++ b/arch/build.gradle
@@ -43,7 +43,6 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}"
     implementation "org.jetbrains.kotlin:kotlin-reflect:${versions.kotlin}"
     //implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlin_version"
-    implementation "com.jakewharton.timber:timber:${versions.timber}"
     implementation "androidx.compose.runtime:runtime:${versions.compose}"
 
     implementation "junit:junit:${versions.junit}"

--- a/arch/src/main/java/dk/ufst/arch/ComposeLocalStore.kt
+++ b/arch/src/main/java/dk/ufst/arch/ComposeLocalStore.kt
@@ -25,9 +25,7 @@ inline fun <LocalValue, LocalAction, GlobalValue, reified GlobalAction, GlobalEn
             val newLocalValue = getLocalCopy(globalValue)
             // Only update value if the local state have changed.
             if (prevLocalValue != newLocalValue) {
-                if (BuildConfig.DEBUG) {
-                    logStateDiff(prevLocalValue!!, newLocalValue!!)
-                }
+                logStateDiff(prevLocalValue!!, newLocalValue!!)
                 value = newLocalValue
             }
             prevLocalValue = newLocalValue

--- a/arch/src/main/java/dk/ufst/arch/ComposeLocalStore.kt
+++ b/arch/src/main/java/dk/ufst/arch/ComposeLocalStore.kt
@@ -6,19 +6,40 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 
+
 interface ComposeLocalStore<Value, Action> {
     val state: State<Value>
-        @Composable
-        get
     fun send(action: Action)
 }
 
 @Composable
 inline fun <LocalValue, LocalAction, GlobalValue, reified GlobalAction, GlobalEnvironment> rememberLocalStore(
     globalStore: GlobalStore<GlobalValue, GlobalAction, GlobalEnvironment>,
-    crossinline getLocalCopy: @DisallowComposableCalls (GlobalValue) -> LocalValue,
-    crossinline getInitialValue: @DisallowComposableCalls (GlobalValue) -> LocalValue,
+    crossinline getLocalCopy: @DisallowComposableCalls (GlobalValue) -> LocalValue
 ): ComposeLocalStore<LocalValue, LocalAction> {
+    var prevLocalValue: LocalValue = remember { getLocalCopy(globalStore.value) }
+
+    val state = produceState(getLocalCopy(globalStore.value)) {
+        val stateChanger: ((GlobalValue) -> Unit) = { globalValue: GlobalValue ->
+
+            val newLocalValue = getLocalCopy(globalValue)
+            // Only update value if the local state have changed.
+            if (prevLocalValue != newLocalValue) {
+                if (BuildConfig.DEBUG) {
+                    logStateDiff(prevLocalValue!!, newLocalValue!!)
+                }
+                value = newLocalValue
+            }
+            prevLocalValue = newLocalValue
+        }
+
+        globalStore.subscribe(stateChanger)
+
+        awaitDispose {
+            globalStore.desubscribe(stateChanger)
+        }
+    }
+
     val localStore = remember {
         object : ComposeLocalStore<LocalValue, LocalAction> {
             override fun send(action: LocalAction) {
@@ -27,37 +48,7 @@ inline fun <LocalValue, LocalAction, GlobalValue, reified GlobalAction, GlobalEn
                 }
             }
 
-            override val state: State<LocalValue>
-                @Composable
-                get() = observeAsState()
-
-            @Composable
-            private fun observeAsState(): State<LocalValue> {
-                var prevLocalValue: LocalValue? = null
-
-                return produceState(getInitialValue(globalStore.value)) {
-                    val stateChanger: ((GlobalValue) -> Unit) = { globalValue: GlobalValue ->
-
-                        val newLocalValue = getLocalCopy(globalValue)
-                        // Only update value if the local state have changed.
-                        if (prevLocalValue != newLocalValue) {
-                            if (BuildConfig.DEBUG) {
-                                prevLocalValue?.let {
-                                    logStateDiff(it, newLocalValue!!)
-                                }
-                            }
-                            value = newLocalValue
-                        }
-                        prevLocalValue = newLocalValue
-                    }
-
-                    globalStore.subscribe(stateChanger)
-
-                    awaitDispose {
-                        globalStore.desubscribe(stateChanger)
-                    }
-                }
-            }
+            override val state: State<LocalValue> = state
         }
     }
 

--- a/arch/src/main/java/dk/ufst/arch/Debug.kt
+++ b/arch/src/main/java/dk/ufst/arch/Debug.kt
@@ -1,6 +1,6 @@
 package dk.ufst.arch
 
-import timber.log.Timber
+import android.util.Log
 import kotlin.math.min
 import kotlin.reflect.KClass
 import kotlin.reflect.full.memberProperties
@@ -9,6 +9,9 @@ const val MAX_LOG_LENGTH = 1000
 const val LOG_TAG = "ReduxArch"
 
 fun log(message: String) {
+    if(!ReduxAndroid.debugMode) {
+        return
+    }
     // Split by line, then ensure each line can fit into Log's maximum length. Borrowed from OkHttp
     // Additional lines get indented
     var i = 0
@@ -18,11 +21,10 @@ fun log(message: String) {
         newline = if (newline != -1) newline else length
         do {
             val end = min(newline, i + MAX_LOG_LENGTH)
-            Timber.tag(LOG_TAG)
             if(i > 0) {
-                Timber.d("\t\t${message.substring(i, end)}")
+                Log.d(LOG_TAG, "\t\t${message.substring(i, end)}")
             } else {
-                Timber.d(message.substring(i, end))
+                Log.d(LOG_TAG, message.substring(i, end))
             }
             i = end
         } while (i < newline)
@@ -45,6 +47,9 @@ fun log(message: String) {
  */
 @Suppress("UNCHECKED_CAST")
 fun logStateDiff(state1: Any, state2: Any) {
+    if(!ReduxAndroid.debugMode) {
+        return
+    }
     log("State update for ${state1::class.simpleName}:")
     // I cannot get rid of the unchecked cast warning but it shouldn't matter since we're getting
     // the class object from the same instance we pass to get(property)

--- a/arch/src/main/java/dk/ufst/arch/Debug.kt
+++ b/arch/src/main/java/dk/ufst/arch/Debug.kt
@@ -36,33 +36,43 @@ fun log(message: String) {
  * it has to call Log for each properties inorder to be in control of the default
  * logcat linebreaking. Lines which are too long get split into several log messages
  * where subsequent ones are indented. This improves readability A LOT
+ *
+ * The catch all exception handler is there because a lot of stuff can go wrong with reflection
+ * for instance if the state is private in a companion object you'll get an IllegalAccessException
+ *
+ * Since debugging output is not crucial we don't allow it to crash, instead we log that we
+ * couldn't log and why.
  */
 @Suppress("UNCHECKED_CAST")
 fun logStateDiff(state1: Any, state2: Any) {
     log("State update for ${state1::class.simpleName}:")
     // I cannot get rid of the unchecked cast warning but it shouldn't matter since we're getting
     // the class object from the same instance we pass to get(property)
-    (state1::class as KClass<Any>).memberProperties.forEach { member ->
-        StringBuilder().apply {
-            val value1 = member.get(state1)
-            val value2 = member.get(state2)
-            if (value1 != value2) {
-                append("\t${member.name}: ")
-                if (value1 is SingleEvent<*>) {
-                    append("SingleEvent(${formatValue(value1.peek())})")
-                } else {
-                    append(formatValue(value1))
+    try {
+        (state1::class as KClass<Any>).memberProperties.forEach { member ->
+            StringBuilder().apply {
+                val value1 = member.get(state1)
+                val value2 = member.get(state2)
+                if (value1 != value2) {
+                    append("\t${member.name}: ")
+                    if (value1 is SingleEvent<*>) {
+                        append("SingleEvent(${formatValue(value1.peek())})")
+                    } else {
+                        append(formatValue(value1))
+                    }
+                    append(" -> ")
+                    if (value2 is SingleEvent<*>) {
+                        append("SingleEvent(${formatValue(value2.peek())})\n")
+                    } else {
+                        append("${formatValue(value2)}\n")
+                    }
                 }
-                append(" -> ")
-                if (value2 is SingleEvent<*>) {
-                    append("SingleEvent(${formatValue(value2.peek())})\n")
-                } else {
-                    append("${formatValue(value2)}\n")
-                }
+            }.also {
+                log(it.toString())
             }
-        }.also {
-            log(it.toString())
         }
+    } catch (t : Throwable) {
+        log("State diff could not be logged. Exception occurred while accessing state members trough reflection:\n\t${t.message}")
     }
 }
 

--- a/arch/src/main/java/dk/ufst/arch/ReduxAndroid.kt
+++ b/arch/src/main/java/dk/ufst/arch/ReduxAndroid.kt
@@ -2,4 +2,15 @@ package dk.ufst.arch
 
 object ReduxAndroid {
     var debugMode = false
+        private set
+
+    private var isInitialized = false
+
+    fun init(debugMode: Boolean) {
+        if(isInitialized) {
+            throw IllegalStateException("You can only call ReduxAndroid.init once")
+        }
+        this.debugMode = debugMode
+        isInitialized = true
+    }
 }

--- a/arch/src/main/java/dk/ufst/arch/ReduxAndroid.kt
+++ b/arch/src/main/java/dk/ufst/arch/ReduxAndroid.kt
@@ -1,0 +1,5 @@
+package dk.ufst.arch
+
+object ReduxAndroid {
+    var debugMode = false
+}

--- a/arch/src/main/java/dk/ufst/arch/Store.kt
+++ b/arch/src/main/java/dk/ufst/arch/Store.kt
@@ -41,6 +41,8 @@ open class GlobalStore<Value, Action, Environment>(
         subscriberList.remove(subscriber)
     }
 
+    fun getSubcriberCount() : Int = subscriberList.size
+
     private fun callSubscribers() {
         subscriberList.forEach { subscriber ->
             subscriber(value)

--- a/arch/src/main/java/dk/ufst/arch/Store.kt
+++ b/arch/src/main/java/dk/ufst/arch/Store.kt
@@ -23,10 +23,8 @@ open class GlobalStore<Value, Action, Environment>(
 
 
     fun sendAction(action: Action) {
-        if(BuildConfig.DEBUG) {
-            log("Dispatching action:")
-            log("\t${getActionDescription(action as Any)}")
-        }
+        log("Dispatching action:")
+        log("\t${getActionDescription(action as Any)}")
         // run on main thread
         executor.runOnUiThread {
             reduce(action, value)

--- a/arch/src/test/java/dk/ufst/arch/ComposeLocalStoreTest.kt
+++ b/arch/src/test/java/dk/ufst/arch/ComposeLocalStoreTest.kt
@@ -92,7 +92,7 @@ class ComposeLocalStoreTest {
     }
 
     @Test
-    fun `Test only one subscription per composable no matter how many state accesses`() {
+    fun `Test only one subscription per ComposeLocalStore no matter how many state accesses`() {
         // Signal an action sent from the Compose scope to the reducer.
         val signalAction = Channel<Unit>(1)
 

--- a/arch/src/test/java/dk/ufst/arch/ComposeLocalStoreTest.kt
+++ b/arch/src/test/java/dk/ufst/arch/ComposeLocalStoreTest.kt
@@ -31,10 +31,8 @@ class ComposeLocalStoreTest {
 
         composeTestRule.setContent {
             val localStore: ComposeLocalStore<LocalState, Any> = rememberLocalStore(
-                globalStore,
-                { it.localState.copy() },
-                { it.localState.copy() }
-            )
+                globalStore
+            ) { it.localState.copy() }
 
             composedResults.add(localStore.state.value)
 
@@ -69,9 +67,7 @@ class ComposeLocalStoreTest {
         composeTestRule.setContent {
             val localStore: ComposeLocalStore<LocalState, Any> = rememberLocalStore(
                 globalStore,
-                { it.localState },
-                { it.localState }
-            )
+            ) { it.localState }
 
             composedResults.add(localStore.state.value)
 
@@ -95,6 +91,40 @@ class ComposeLocalStoreTest {
         }
     }
 
+    @Test
+    fun `Test only one subscription per composable no matter how many state accesses`() {
+        // Signal an action sent from the Compose scope to the reducer.
+        val signalAction = Channel<Unit>(1)
+
+        composeTestRule.setContent {
+            val localStore: ComposeLocalStore<LocalState, Any> = rememberLocalStore(
+                globalStore
+            ) { it.localState.copy() }
+
+            // Access the state 2 times
+            localStore.state.value
+            localStore.state.value
+
+            val scope = rememberCoroutineScope()
+
+            // Wait for outside signal for when to sent an Action.
+            scope.launch {
+                signalAction.consumeEach {
+                    localStore.send(Any())
+                }
+            }
+        }
+
+        composeTestRule.runOnIdle {
+            signalAction.trySend(Unit)
+        }
+
+        composeTestRule.runOnIdle {
+            // Make sure that only one subscription is created
+            assertEquals(1, globalStore.getSubcriberCount())
+        }
+    }
+
     private fun setupStore() {
         globalStore = GlobalStore(
             env = Any(),
@@ -108,9 +138,8 @@ class ComposeLocalStoreTest {
                     pullback(
                         localReducer,
                         AppState::localState::get,
-                        AppState::localState::set,
-                        { Any() }
-                    )
+                        AppState::localState::set
+                    ) { Any() }
                 )
             )
         )

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ buildscript {
         archCore        : '2.1.0',
         lifecycle       : '2.4.0',
         junit           : '4.13.1',
-        timber          : '4.7.1',
         compose         : '1.1.0-rc01'
     ]
 


### PR DESCRIPTION
- Changed to @patrickusiewicz  latest implementation of ComposeLocalStore instead of the one using RememberObserver.
- Implemented a function in GlobalStore to get current subscriber count.
- Added a test that makes sure there is only one subscriber per composable even though they have multiple state accesses.
- Added ReduxAndroid.debugMode simple flag which enables/disables logging in the ReduxArch lib.
- Removed Timber dependency from the library and replaced with good old android logger.
- Added a catch all exception handler to the state diff logger so that it doesn't crash if it cannot access a state member, instead it logs the exception.
- Removed getInitialValue parameter from rememberLocalStore since we couldn't for now come up where a scenario where it wouldn't always be identical to getLocalCopy thus cluttering the code.