### PR TITLE
Select effect dispatcher (optional) and fixed effect cancelling for views apps

### DIFF
--- a/arch/src/main/java/dk/ufst/arch/ComposeLocalStore.kt
+++ b/arch/src/main/java/dk/ufst/arch/ComposeLocalStore.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 
 interface ComposeLocalStore<Value, Action> {
@@ -16,6 +17,7 @@ interface ComposeLocalStore<Value, Action> {
 @Composable
 inline fun <LocalValue, LocalAction, GlobalValue, reified GlobalAction, GlobalEnvironment> rememberLocalStore(
     globalStore: GlobalStore<GlobalValue, GlobalAction, GlobalEnvironment>,
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
     crossinline getLocalCopy: @DisallowComposableCalls (GlobalValue) -> LocalValue
 ): ComposeLocalStore<LocalValue, LocalAction> {
     var prevLocalValue: LocalValue = remember { getLocalCopy(globalStore.value) }
@@ -38,7 +40,7 @@ inline fun <LocalValue, LocalAction, GlobalValue, reified GlobalAction, GlobalEn
         }
     }
 
-    val scope = rememberCoroutineScope { Dispatchers.Default }
+    val scope = rememberCoroutineScope { dispatcher }
     val localStore: ComposeLocalStore<LocalValue, LocalAction> = remember {
         object : ComposeLocalStore<LocalValue, LocalAction> {
             override fun send(action: LocalAction) {

--- a/arch/src/main/java/dk/ufst/arch/ReduxViewModel.kt
+++ b/arch/src/main/java/dk/ufst/arch/ReduxViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.*
 @Suppress("unused")
 abstract class ReduxViewModel<LocalValue, LocalAction> : ViewModel(), DefaultLifecycleObserver {
     private val value = MutableLiveData<LocalValue>()
-
     abstract val store : LocalStore<LocalValue, LocalAction>
 
     private val subscription : (LocalValue)->Unit = { state ->


### PR DESCRIPTION
- rememberLocalStore can be passed an optional dispatcher argument if you want to run your effects on another dispatcher than Dispatcher.Default
- createLocalStore likewise takes an optional dispatcher argument.
- LocalStore now cancel its effect like ComposeLocalStore, changes to hostapp needed (unless you want to run on another dispatcher)