### PR TITLE
Main is default dispatcher in rememberLocalStore

### DIFF
--- a/arch/src/main/java/dk/ufst/arch/ComposeLocalStore.kt
+++ b/arch/src/main/java/dk/ufst/arch/ComposeLocalStore.kt
@@ -17,7 +17,7 @@ interface ComposeLocalStore<Value, Action> {
 @Composable
 inline fun <LocalValue, LocalAction, GlobalValue, reified GlobalAction, GlobalEnvironment> rememberLocalStore(
     globalStore: GlobalStore<GlobalValue, GlobalAction, GlobalEnvironment>,
-    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    dispatcher: CoroutineDispatcher = Dispatchers.Main,
     crossinline getLocalCopy: @DisallowComposableCalls (GlobalValue) -> LocalValue
 ): ComposeLocalStore<LocalValue, LocalAction> {
     var prevLocalValue: LocalValue = remember { getLocalCopy(globalStore.value) }

--- a/redux-sample/src/main/java/dk/ufst/arch/redux_sample/domain/environment/ApiClient.kt
+++ b/redux-sample/src/main/java/dk/ufst/arch/redux_sample/domain/environment/ApiClient.kt
@@ -1,6 +1,6 @@
 package dk.ufst.arch.redux_sample.domain.environment
 
 interface ApiClient {
-    fun getContacts() : Result<List<Contact>>
-    fun getMessages(contactId: String) : Result<List<Message>>
+    suspend fun getContacts() : Result<List<Contact>>
+    suspend fun getMessages(contactId: String) : Result<List<Message>>
 }

--- a/redux-sample/src/main/java/dk/ufst/arch/redux_sample/domain/environment/ApiClientMock.kt
+++ b/redux-sample/src/main/java/dk/ufst/arch/redux_sample/domain/environment/ApiClientMock.kt
@@ -1,19 +1,21 @@
 package dk.ufst.arch.redux_sample.domain.environment
 
-private fun simulateLoadTime() {
+import kotlinx.coroutines.delay
+
+private suspend fun simulateLoadTime() {
     val loadTime = 200 + (Math.random() * 1000)
-    Thread.sleep(loadTime.toLong())
+    delay(loadTime.toLong())
 }
 
 class ApiClientMock : ApiClient {
 
-    override fun getContacts() : Result<List<Contact>> = runCatching {
+    override suspend fun getContacts() : Result<List<Contact>> = runCatching {
         //throw RuntimeException("Could not load contacts")
         simulateLoadTime()
         mockContacts
     }
 
-    override fun getMessages(contactId: String): Result<List<Message>> = runCatching {
+    override suspend fun getMessages(contactId: String): Result<List<Message>> = runCatching {
         simulateLoadTime()
         mockMessages[contactId]!!
     }


### PR DESCRIPTION
We want to utilize Kotlin's suspend functions in the side effects. Therefor it makes sense to use the Main dispatcher for running side effects, because suspend functions should be safe to call from the main thread. In this case it makes the Default dispatcher redundant. This will move the responsibility of changing thread/dispatcher to suspend functions called in the side effects or libraries that support suspend functions like Retrofit and Room.

This PR only changes the default dispatcher in the `rememberLocalStore` function, so we don't introduce breaking changes in some of our apps. We will at a later point make a new PR that update `createLocalStore` to use the `Main` dispatcher as the default dispatcher.

`ApiClient` in the sample app was updated to use suspend functions to simulator real usages of suspend functions.